### PR TITLE
feat: Add signature size

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -70,6 +70,9 @@ class Url
     {
         $data = $this->builder->getSalt() . $unsignedPath;
         $sha256 = hash_hmac('sha256', $data, $this->builder->getKey(), true);
+        if ($this->builder->getSignatureSize() > 0) {
+            $sha256 = substr($sha256, 0, $this->builder->getSignatureSize());
+        }
         $sha256Encoded = base64_encode($sha256);
         $signature = str_replace(["+", "/", "="], ["-", "_", ""], $sha256Encoded);;
         return "/{$signature}{$unsignedPath}";

--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -25,18 +25,24 @@ class UrlBuilder
     private $secure = false;
 
     /**
+     * @var int
+     */
+    private $signatureSize;
+
+    /**
      * UrlBuilder constructor.
      * @param string $baseUrl
      * @param string $key
      * @param string $salt
      * @throws Exception
      */
-    public function __construct(string $baseUrl, string $key = null, string $salt = null)
+    public function __construct(string $baseUrl, string $key = null, string $salt = null, $signatureSize = 0)
     {
         if ($key && $salt) {
             $this->key = pack("H*" , $key) ?: $this->throwException("Key expected to be hex-encoded string");
             $this->salt = pack("H*" , $salt) ?: $this->throwException("Salt expected to be hex-encoded string");
             $this->secure = true;
+            $this->signatureSize = $signatureSize;
         }
 
         $this->baseUrl = $baseUrl;
@@ -85,6 +91,14 @@ class UrlBuilder
     public function isSecure(): bool
     {
         return $this->secure;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSignatureSize(): int
+    {
+        return $this->signatureSize;
     }
 
     /**

--- a/test/UrlTest.php
+++ b/test/UrlTest.php
@@ -14,6 +14,7 @@ class UrlTest extends TestCase
     const BASE_URL = "http://imgproxy";
     const IMAGE_URL = "local:///file.jpg";
     const IMAGE_URL_WITH_QUERY = "http://storage.recrm.ru/Static/13083_8483b9/11/WSIMG/1200_795_I_MC_jpg_W/resources/properties/1668/picture_0009.jpg?F80A64FF1B6E8585909336490F78A1E4";
+    const SIGNATURE_SIZE = 8;
 
     /**
      * @param string $fit
@@ -46,6 +47,12 @@ class UrlTest extends TestCase
         $this->assertEquals("/-o6q11Q3DrNtMnCz_bZQzPdDxrGgx9BfVqQBbndAOwo/fit/300/200/sm/0/bG9jYWw6Ly8vZmlsZS5qcGc.jpg", $url->signedPath());
     }
 
+    public function testSignedPathWithSignatureSize()
+    {
+        $url = new Url($this->secureUrlBuilderWithSignatureSize(), self::IMAGE_URL, 300, 200);
+        $this->assertEquals("/-o6q11Q3DrM/fit/300/200/sm/0/bG9jYWw6Ly8vZmlsZS5qcGc.jpg", $url->signedPath());
+    }
+
     public function testSignedPathWithQueryString()
     {
         $url = new Url($this->secureUrlBuilder(), self::IMAGE_URL_WITH_QUERY, 1200, 900);
@@ -62,6 +69,11 @@ class UrlTest extends TestCase
     protected function secureUrlBuilder(): UrlBuilder
     {
         return new UrlBuilder(self::BASE_URL, self::KEY, self::SALT);
+    }
+
+    protected function secureUrlBuilderWithSignatureSize(): UrlBuilder
+    {
+        return new UrlBuilder(self::BASE_URL, self::KEY, self::SALT, self::SIGNATURE_SIZE);
     }
 
     protected function insecureUrlBuilder(): UrlBuilder


### PR DESCRIPTION
This PR adds an extra option to set the signature size, from [the docs](https://github.com/imgproxy/imgproxy/blob/master/docs/configuration.md#url-signature):

<img width="1055" alt="Screenshot 2021-09-02 at 15 47 48" src="https://user-images.githubusercontent.com/8616978/131855211-595a9638-8e44-41d9-8a6e-b819a0840e20.png">

With the condition and having 0 as default value it shouldn't bring any breaking changes.