### PR TITLE
Allow setting custom options

### DIFF
--- a/src/OptionSet.php
+++ b/src/OptionSet.php
@@ -13,7 +13,7 @@ class OptionSet
      */
     private $options = [];
 
-    public function set(string $name, ...$args): self
+    private function set(string $name, ...$args): self
     {
         $this->options[$name] = $args;
         return $this;

--- a/src/OptionSet.php
+++ b/src/OptionSet.php
@@ -13,10 +13,15 @@ class OptionSet
      */
     private $options = [];
 
-    public function set(string $name, ...$args): self
+    private function set(string $name, ...$args): self
     {
         $this->options[$name] = $args;
         return $this;
+    }
+
+    public function setUnsafe(string $name, ...$args): self
+    {
+        return $this->set($name, ...$args);
     }
 
     public function unset(string $name): self

--- a/src/OptionSet.php
+++ b/src/OptionSet.php
@@ -13,7 +13,7 @@ class OptionSet
      */
     private $options = [];
 
-    private function set(string $name, ...$args): self
+    public function set(string $name, ...$args): self
     {
         $this->options[$name] = $args;
         return $this;

--- a/test/OptionSetTest.php
+++ b/test/OptionSetTest.php
@@ -11,6 +11,7 @@ use Imgproxy\Rotate;
 use Imgproxy\UnsharpeningMode;
 use Imgproxy\WatermarkPosition;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 class OptionSetTest extends TestCase
 {
@@ -971,6 +972,23 @@ class OptionSetTest extends TestCase
         $os = new OptionSet();
         $os->withQuality(70);
         $this->assertEquals(70, $os->quality());
+    }
+
+    public function testSetUnsafe(): void
+    {
+        $os = new OptionSet();
+        $optionName = 'zoom';
+        $args = ['2', '2'];
+
+        $os->setUnsafe($optionName, ...$args);
+
+        $reflectionClass = new ReflectionClass(OptionSet::class);
+        $optionsProperty = $reflectionClass->getProperty('options');
+        $optionsProperty->setAccessible(true);
+        $options = $optionsProperty->getValue($os);
+
+        $this->assertArrayHasKey($optionName, $options);
+        $this->assertSame($args, $options[$optionName]);
     }
 
     public function testUnset()


### PR DESCRIPTION
Changing the visibility of the `set()` method in the `OptionSet` class from private to public allows us to set arbitrary settings using a text string.

For example, I want to be able to do this;

```php
$customProcessingOptions = 'zoom:2:2/blur:4';
$options = array_map('trim', explode('/', $customProcessingOptions));
foreach ($options as $option) {
    $arguments = explode(':', $option);
    $name = array_shift($arguments);
    $url->options()->set($name, ...$arguments);
}
```

For a real life example, see https://github.com/elgentos/magento2-imgproxy/pull/1/commits/50f1455228aae1323740ee871cf0b4b24652767d#diff-c5ca923b6d96fb8bb165a2634b824b6209bb35097555ff7cad065506f35b0c0cR77