### PR TITLE
PHPDoc tag @return with type bool is incompatible with native type string

### DIFF
--- a/src/UrlBuilder.php
+++ b/src/UrlBuilder.php
@@ -72,17 +72,11 @@ class UrlBuilder
         return $this->baseUrl;
     }
 
-    /**
-     * @return bool
-     */
     public function getSalt(): string
     {
         return $this->salt;
     }
 
-    /**
-     * @return bool
-     */
     public function getKey(): string
     {
         return $this->key;


### PR DESCRIPTION
Static analyzer get crazy about incorrect type in PHPDoc.

Also, thanks for the great package!